### PR TITLE
rigorous computation of eigenvalues of matrices

### DIFF
--- a/docs/src/api/eigenvalues.md
+++ b/docs/src/api/eigenvalues.md
@@ -1,8 +1,11 @@
+# Eigenvalues computations
+
 ```@index
 Pages = ["eigenvalues.md"]
 ```
 
 ## Interval matrices eigenvalues
+
 ```@autodocs
 Modules=[IntervalLinearAlgebra]
 Pages=["interval_eigenvalues.jl"]

--- a/docs/src/api/eigenvalues.md
+++ b/docs/src/api/eigenvalues.md
@@ -2,9 +2,18 @@
 Pages = ["eigenvalues.md"]
 ```
 
+## Interval matrices eigenvalues
 ```@autodocs
 Modules=[IntervalLinearAlgebra]
 Pages=["interval_eigenvalues.jl"]
+Private=false
+```
+
+## Floating point eigenvalues verification
+
+```@autodocs
+Modules=[IntervalLinearAlgebra]
+Pages=["verify_eigs.jl"]
 Private=false
 ```
 

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -211,6 +211,33 @@ S.M. Rump, [*Verification methods: Rigorous results using floating-point arithme
 ```
 ---
 
+#### [RUM01]
+
+```@raw html
+<ul><li>
+```
+Rump, Siegfried M. [*Computational error bounds for multiple or nearly multiple eigenvalues*](https://www.tuhh.de/ti3/paper/rump/Ru99c.pdf), Linear algebra and its applications 324.1-3 (2001): 209-226.
+```@raw html
+<li style="list-style: none"><details>
+<summary>bibtex</summary>
+```
+```
+@article{rump2001computational,
+  title={Computational error bounds for multiple or nearly multiple eigenvalues},
+  author={Rump, Siegfried M},
+  journal={Linear algebra and its applications},
+  volume={324},
+  number={1-3},
+  pages={209--226},
+  year={2001},
+  publisher={Elsevier}
+}
+```
+```@raw html
+</details></li></ul>
+```
+---
+
 #### [RUM99]
 
 ```@raw html

--- a/src/IntervalLinearAlgebra.jl
+++ b/src/IntervalLinearAlgebra.jl
@@ -16,6 +16,8 @@ end
 
 @reexport using LinearAlgebra, IntervalArithmetic
 
+const IA = IntervalArithmetic
+
 export
     set_multiplication_mode, get_multiplication_mode,
     LinearKrawczyk, Jacobi, GaussSeidel, GaussianElimination, HansenBliekRohn, NonLinearOettliPrager, LinearOettliPrager,
@@ -24,7 +26,7 @@ export
     comparison_matrix, interval_norm, interval_isapprox, Orthants,
     is_H_matrix, is_strongly_regular, is_strictly_diagonally_dominant, is_Z_matrix, is_M_matrix,
     rref,
-    eigenbox
+    eigenbox, verify_eigenvalues, bound_perron_frobenius_eigenvalue
 
 
 include("linear_systems/enclosures.jl")
@@ -38,4 +40,5 @@ include("classify.jl")
 include("rref.jl")
 
 include("eigenvalues/interval_eigenvalues.jl")
+include("eigenvalues/verify_eigs.jl")
 end

--- a/src/IntervalLinearAlgebra.jl
+++ b/src/IntervalLinearAlgebra.jl
@@ -26,7 +26,7 @@ export
     comparison_matrix, interval_norm, interval_isapprox, Orthants,
     is_H_matrix, is_strongly_regular, is_strictly_diagonally_dominant, is_Z_matrix, is_M_matrix,
     rref,
-    eigenbox, verify_eigenvalues, bound_perron_frobenius_eigenvalue
+    eigenbox, verify_eigen, bound_perron_frobenius_eigenvalue
 
 
 include("linear_systems/enclosures.jl")

--- a/src/eigenvalues/verify_eigs.jl
+++ b/src/eigenvalues/verify_eigs.jl
@@ -55,7 +55,7 @@ as simple.
 
 ### Algorithm
 
-The algorithm for this function is described in [[RUM99b]](@ref).
+The algorithm for this function is described in [[RUM01]](@ref).
 
 ### Example
 
@@ -102,9 +102,27 @@ end
 
 
 """
-    bound_perron_frobenius_eigenvalue(A)
+    bound_perron_frobenius_eigenvalue(A, max_iter=10)
 
 Finds an upper bound for the Perron-Frobenius eigenvalue of the **non-negative** matrix `A`.
+
+### Input
+
+- `A` -- square real non-negative matrix
+- `max_iter` -- maximum number of iterations of the power method used internally to compute
+    an initial approximation of the Perron-Frobenius eigenvector
+
+### Example
+
+```julia-repl
+julia> A = [1 2;3 4]
+2×2 Matrix{Int64}:
+ 1  2
+ 3  4
+
+julia> bound_perron_frobenius_eigenvalue(A)
+5.372281323275249
+```
 """
 function bound_perron_frobenius_eigenvalue(A::AbstractMatrix{T}, max_iter=10) where {T<:Real}
     any(A .< 0) && throw(ArgumentError("Matrix contains negative entries"))

--- a/src/eigenvalues/verify_eigs.jl
+++ b/src/eigenvalues/verify_eigs.jl
@@ -1,73 +1,57 @@
-"""
-    verify_eigenvalues(A, λ, X0; k=0.1, ϵ=1e-16, maxiter=10)
+function verify_eigen(A::Symmetric{T, Matrix{T}}, λ::Number, X0::AbstractVector;
+                      w=0.1, ϵ=floatmin(), maxiter=10) where {T}
 
-Finds a rigorous bound for a given eigenvalue and the associated eigenvector(s) starting
-from the approximate solutions `λ`, `X0`.
+    _, v = findmax(abs.(X0))
 
-### Input
-
-- `A`  -- matrix whose eigenvalue we want to compute
-- `λ`  -- approximate value for an eigenvalue of `A`
-- `X0` -- eigenvectors associated to `λ`, one for each column of X0
-
-### Output
-
-- An interval bound for `λ`
-- An interval bound for `X0`
-- A boolean certificate `cert`. If `cert==true`, then the bounds are rigorous, otherwise
-  not.
-"""
-function verify_eigenvalues(A::Symmetric{T, Matrix{T}},
-                            λ::Number, X0;
-                            k=0.1, ϵ=floatmin(), maxiter=10) where {T}
-    n = size(X0, 1)
-    k = size(X0, 2)
-
-    u = 1:n-k
-    v = n-k+1:n
     R = mid.(A) - λ * I
-    R[:, v] = -X0
+    R[:, v] .= -X0
     R = inv(R)
     C = IA.Interval.(A) - λ * I
     Z = -R * (C * X0)
-    C[:, v] = -X0
-    C = I - R * C
+    C[:, v] .= -X0
+    C = I - Interval.(R) * C
+    Zinfl = w * ( IA.Interval.(-mag.(Z), mag.(Z)) .+ IA.Interval(-ϵ, ϵ) )
 
-    Zinfl = IA.Interval.(-0.1*mag.(Z) .- ϵ, 0.1*mag.(Z) .+ ϵ)
     X = Z
     cert = false
-    for _ in 1:maxiter
+    @inbounds for _ in 1:maxiter
         Y = X + Zinfl
-        Ytmp = copy(Y)
-        Ytmp[v, :] .= 0
-        X = Z + C * Y + R * (Ytmp * Y[v, :])
+        Ytmp = Y * Y[v]
+        Ytmp[v] = 0
+
+        X = Z + C * Y + R * Ytmp
         cert = all(X .⊂ Y)
         cert && break
     end
 
-    M = mag.(view(X, v, :))
-    @show length(M)
-    ρ = _bound_perron_frobenius_eigenvalue(M)
+    ρ = mag(X[v])
+    X[v] = 0
 
-    X[v, :] .= 0
     return λ ± ρ, X0 + X, cert
 end
 
+
 """
-    verify_eigenvalues(A; k=0.1, ϵ=1e-16, maxiter=10)
+    verify_eigen(A[, λ, X0]; w=0.1, ϵ=1e-16, maxiter=10)
 
 Finds a rigorous bound for the eigenvalues and eigenvectors of `A`. Eigenvalues are treated
 as simple.
 
 ### Input
 
-- `A`  -- matrix whose eigenvalue we want to compute
+- `A`       -- matrix
+- `λ`       -- (optional) approximate value for an eigenvalue of `A`
+- `X0`      -- (optional) eigenvector associated to `λ`
+- `w`       -- relative inflation parameter
+- `ϵ`       -- absolute inflation parameter
+- `maxiter` -- maximum number of iterations
 
 ### Output
 
-- An object of type `Eigen` containing interval eigenvalues and eigenvectors.
-- A boolean vector of certificates `cert`. If `cert[i]==true`, then the bounds for the ith
-eigenvalue and eigenvectore are rigorous, otherwise not.
+- Interval bounds on eigenvalues and eigenvectors.
+- A boolean certificate (or a vector of booleans if all eigenvalues are computed) `cert`.
+  If `cert[i]==true`, then the bounds for the ith eigenvalue and eigenvectore are rigorous,
+  otherwise not.
 
 ### Algorithm
 
@@ -76,41 +60,77 @@ The algorithm for this function is described in [[RUM99b]](@ref).
 ### Example
 
 ```julia
-julia> A = [1 2;3 4]
-2×2 Matrix{Int64}:
-    1  2
-    3  4
+julia> A = Symmetric([1 2;2 3])
+2×2 Symmetric{Int64, Matrix{Int64}}:
+ 1  2
+ 2  3
 
-julia> ev, cert = verify_eigenvalues(A);
+julia> evals, evecs, cert = verify_eigen(A);
 
-julia> ev
-Eigen{Interval{Float64}, Interval{Float64}, Matrix{Interval{Float64}}, Vector{Interval{Float64}}}
-values:
+julia> evals
 2-element Vector{Interval{Float64}}:
-    [-0.372282, -0.372281]
-    [5.37228, 5.37229]
-vectors:
+ [-0.236068, -0.236067]
+  [4.23606, 4.23607]
+
+julia> evecs
 2×2 Matrix{Interval{Float64}}:
-    [-0.824565, -0.824564]  [-0.415974, -0.415973]
-    [0.565767, 0.565768]   [-0.909377, -0.909376]
+ [-0.850651, -0.85065]  [0.525731, 0.525732]
+  [0.525731, 0.525732]  [0.85065, 0.850651]
 
 julia> cert
 2-element Vector{Bool}:
-    1
-    1
+ 1
+ 1
 ```
 """
-function verify_eigenvalues(A::Symmetric{T, Matrix{T}}; kwargs...) where {T<:Real}
-    tmp = eigen(mid.(A))
-    ev = IA.Interval.(similar(tmp.values))
-    vectors = IA.Interval.(similar(tmp.vectors))
-    cert = similar(tmp.values, Bool)
-    for i in 1:length(ev)
-        λ, v, flag = verify_eigenvalues(A, tmp.values[i], tmp.vectors[:,i]; kwargs...)
-        ev[i] = λ
-        vectors[:, i] = v
+function verify_eigen(A::Symmetric{T, Matrix{T}}; kwargs...) where {T<:Real}
+    evals, evecs = eigen(mid.(A))
+
+    evalues = IA.Interval.(similar(evals))
+    evectors = IA.Interval.(similar(evecs))
+
+    cert = Vector{Bool}(undef, length(evals))
+    @inbounds for (i, λ₀) in enumerate(evals)
+        λ, v, flag = verify_eigen(A, λ₀, view(evecs, :,i); kwargs...)
+        evalues[i] = λ
+        evectors[:, i] .= v
         cert[i] = flag
 
     end
-    return Eigen(ev, vectors), cert
+    return evalues, evectors, cert
+end
+
+
+"""
+    bound_perron_frobenius_eigenvalue(A)
+
+Finds an upper bound for the Perron-Frobenius eigenvalue of the **non-negative** matrix `A`.
+"""
+function bound_perron_frobenius_eigenvalue(A::AbstractMatrix{T}, max_iter=10) where {T<:Real}
+    any(A .< 0) && throw(ArgumentError("Matrix contains negative entries"))
+    return _bound_perron_frobenius_eigenvalue(A, max_iter)
+end
+
+function _bound_perron_frobenius_eigenvalue(M, max_iter=10)
+
+    size(M, 1) == 1 && return M[1]
+    xpf = IA.Interval.(_power_iteration(M, max_iter))
+    Mxpf = M * xpf
+    ρ = zero(eltype(M))
+    @inbounds for (i, xi) in enumerate(xpf)
+        iszero(xi) && continue
+        tmp = Mxpf[i] / xi
+        ρ = max(ρ, tmp.hi)
+    end
+    return ρ
+end
+
+function _power_iteration(A, max_iter)
+    n = size(A,1)
+    xp = rand(n)
+    @inbounds for _ in 1:max_iter
+    xp .= A*xp
+    xp ./= norm(xp)
+    end
+    return xp
 end

--- a/src/eigenvalues/verify_eigs.jl
+++ b/src/eigenvalues/verify_eigs.jl
@@ -75,7 +75,7 @@ end
 
 function verify_eigen(A::Symmetric, λ, X0; kwargs...)
     ρ, X, cert = _verify_eigen(A, λ, X0; kwargs...)
-    return λ ± ρ, X0 + X, cert
+    return λ ± ρ, X0 + real.(X), cert
 end
 
 function _verify_eigen(A, λ::Number, X0::AbstractVector;
@@ -92,14 +92,10 @@ function _verify_eigen(A, λ::Number, X0::AbstractVector;
     C = I - R * C
     Zinfl = w * IA.Interval.(-mag.(Z), mag.(Z)) .+ IA.Interval(-ϵ, ϵ)
 
-    X = Z
+    X = Complex.(Z)
     cert = false
     @inbounds for _ in 1:maxiter
-        if eltype(X) <: Complex # TODO: use dispatch
-            Y = (real.(X) + Zinfl) + (imag.(X) + Zinfl) * im
-        else
-            Y = X + Zinfl
-        end
+        Y = (real.(X) + Zinfl) + (imag.(X) + Zinfl) * im
 
         Ytmp = Y * Y[v]
         Ytmp[v] = 0

--- a/src/eigenvalues/verify_eigs.jl
+++ b/src/eigenvalues/verify_eigs.jl
@@ -1,0 +1,116 @@
+"""
+    verify_eigenvalues(A, λ, X0; k=0.1, ϵ=1e-16, maxiter=10)
+
+Finds a rigorous bound for a given eigenvalue and the associated eigenvector(s) starting
+from the approximate solutions `λ`, `X0`.
+
+### Input
+
+- `A`  -- matrix whose eigenvalue we want to compute
+- `λ`  -- approximate value for an eigenvalue of `A`
+- `X0` -- eigenvectors associated to `λ`, one for each column of X0
+
+### Output
+
+- An interval bound for `λ`
+- An interval bound for `X0`
+- A boolean certificate `cert`. If `cert==true`, then the bounds are rigorous, otherwise
+  not.
+"""
+function verify_eigenvalues(A::Symmetric{T, Matrix{T}},
+                            λ::Number, X0;
+                            k=0.1, ϵ=floatmin(), maxiter=10) where {T}
+    n = size(X0, 1)
+    k = size(X0, 2)
+
+    u = 1:n-k
+    v = n-k+1:n
+    R = mid.(A) - λ * I
+    R[:, v] = -X0
+    R = inv(R)
+    C = IA.Interval.(A) - λ * I
+    Z = -R * (C * X0)
+    C[:, v] = -X0
+    C = I - R * C
+
+    Zinfl = IA.Interval.(-0.1*mag.(Z) .- ϵ, 0.1*mag.(Z) .+ ϵ)
+    X = Z
+    cert = false
+    for _ in 1:maxiter
+        Y = X + Zinfl
+        Ytmp = copy(Y)
+        Ytmp[v, :] .= 0
+        X = Z + C * Y + R * (Ytmp * Y[v, :])
+        cert = all(X .⊂ Y)
+        cert && break
+    end
+
+    M = mag.(view(X, v, :))
+    @show length(M)
+    ρ = _bound_perron_frobenius_eigenvalue(M)
+
+    X[v, :] .= 0
+    return λ ± ρ, X0 + X, cert
+end
+
+"""
+    verify_eigenvalues(A; k=0.1, ϵ=1e-16, maxiter=10)
+
+Finds a rigorous bound for the eigenvalues and eigenvectors of `A`. Eigenvalues are treated
+as simple.
+
+### Input
+
+- `A`  -- matrix whose eigenvalue we want to compute
+
+### Output
+
+- An object of type `Eigen` containing interval eigenvalues and eigenvectors.
+- A boolean vector of certificates `cert`. If `cert[i]==true`, then the bounds for the ith
+eigenvalue and eigenvectore are rigorous, otherwise not.
+
+### Algorithm
+
+The algorithm for this function is described in [[RUM99b]](@ref).
+
+### Example
+
+```julia
+julia> A = [1 2;3 4]
+2×2 Matrix{Int64}:
+    1  2
+    3  4
+
+julia> ev, cert = verify_eigenvalues(A);
+
+julia> ev
+Eigen{Interval{Float64}, Interval{Float64}, Matrix{Interval{Float64}}, Vector{Interval{Float64}}}
+values:
+2-element Vector{Interval{Float64}}:
+    [-0.372282, -0.372281]
+    [5.37228, 5.37229]
+vectors:
+2×2 Matrix{Interval{Float64}}:
+    [-0.824565, -0.824564]  [-0.415974, -0.415973]
+    [0.565767, 0.565768]   [-0.909377, -0.909376]
+
+julia> cert
+2-element Vector{Bool}:
+    1
+    1
+```
+"""
+function verify_eigenvalues(A::Symmetric{T, Matrix{T}}; kwargs...) where {T<:Real}
+    tmp = eigen(mid.(A))
+    ev = IA.Interval.(similar(tmp.values))
+    vectors = IA.Interval.(similar(tmp.vectors))
+    cert = similar(tmp.values, Bool)
+    for i in 1:length(ev)
+        λ, v, flag = verify_eigenvalues(A, tmp.values[i], tmp.vectors[:,i]; kwargs...)
+        ev[i] = λ
+        vectors[:, i] = v
+        cert[i] = flag
+
+    end
+    return Eigen(ev, vectors), cert
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,5 @@
 mid(x::Real) = x
+mid(x::Complex) = x
 
 """
     interval_isapprox(a::Interval, b::Interval; kwargs)
@@ -172,3 +173,7 @@ end
 
 Base.firstindex(O::Orthants) = 1
 Base.lastindex(O::Orthants) = length(O)
+
+
+_unchecked_interval(x::Real) = Interval(x)
+_unchecked_interval(x::Complex) = Interval(real(x)) + Interval(imag(x)) * im

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -172,25 +172,3 @@ end
 
 Base.firstindex(O::Orthants) = 1
 Base.lastindex(O::Orthants) = length(O)
-
-"""
-    bound_perron_frobenius_eigenvalue(A)
-
-Finds an upper bound for the Perron-Frobenius eigenvalue of the **non-negative** matrix `A`.
-"""
-function bound_perron_frobenius_eigenvalue(A::Matrix{T}) where {T<:Real}
-    any(A .< 0) && throw(ArgumentError("Matrix contains negative entries"))
-    return _bound_perron_frobenius_eigenvalue(A)
-end
-
-function _bound_perron_frobenius_eigenvalue(M::Matrix{T}) where {T<:Real}
-    if length(M) == 1 # case of 1x1 matrix
-        ρ = M[1]
-    else
-        ev = eigvecs(M)
-        xpf = abs.(ev[:, end])
-        tmp = sup.((IA.Interval.(M) * IA.Interval.(xpf)) ./ IA.Interval.(xpf))
-        ρ = maximum(tmp)
-    end
-    return ρ
-end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -172,3 +172,25 @@ end
 
 Base.firstindex(O::Orthants) = 1
 Base.lastindex(O::Orthants) = length(O)
+
+"""
+    bound_perron_frobenius_eigenvalue(A)
+
+Finds an upper bound for the Perron-Frobenius eigenvalue of the **non-negative** matrix `A`.
+"""
+function bound_perron_frobenius_eigenvalue(A::Matrix{T}) where {T<:Real}
+    any(A .< 0) && throw(ArgumentError("Matrix contains negative entries"))
+    return _bound_perron_frobenius_eigenvalue(A)
+end
+
+function _bound_perron_frobenius_eigenvalue(M::Matrix{T}) where {T<:Real}
+    if length(M) == 1 # case of 1x1 matrix
+        ρ = M[1]
+    else
+        ev = eigvecs(M)
+        xpf = abs.(ev[:, end])
+        tmp = sup.((IA.Interval.(M) * IA.Interval.(xpf)) ./ IA.Interval.(xpf))
+        ρ = maximum(tmp)
+    end
+    return ρ
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,8 @@ include("test_utils.jl")
 
 
 include("test_eigenvalues/test_interval_eigenvalues.jl")
-
+include("test_eigenvalues/test_verify_eigs.jl")
 include("test_solvers/test_enclosures.jl")
 include("test_solvers/test_epsilon_inflation.jl")
-include("test_solvers/test_oettli_prager.jl")
 include("test_solvers/test_precondition.jl")
+include("test_solvers/test_oettli_prager.jl")

--- a/test/test_eigenvalues/test_verify_eigs.jl
+++ b/test/test_eigenvalues/test_verify_eigs.jl
@@ -11,7 +11,7 @@ end
     Q, _ = qr(rand(n, n))
     A = Symmetric(IA.Interval.(Q) * D * IA.Interval.(Q)')
 
-    F, cert = verify_eigenvalues(A)
+    evals, evecs, cert = verify_eigen(A)
     @test all(cert)
-    @test all(ev .∈ F.values)
+    @test all(ev .∈ evals)
 end

--- a/test/test_eigenvalues/test_verify_eigs.jl
+++ b/test/test_eigenvalues/test_verify_eigs.jl
@@ -21,7 +21,7 @@ end
     # real eigenvalues case
     P = rand(n, n)
     Pinv, _ = epsilon_inflation(P, Diagonal(ones(n)))
-    A = IA.Interval.(P) * IA.Interval.(D) * Pinv
+    A = IA.Interval.(P) * D * Pinv
 
     evals, evecs, cert = verify_eigen(A)
     @test all(cert)

--- a/test/test_eigenvalues/test_verify_eigs.jl
+++ b/test/test_eigenvalues/test_verify_eigs.jl
@@ -1,0 +1,17 @@
+@testset "verify perron frobenius " begin
+    A = [1 2;3 4]
+    ρ = bound_perron_frobenius_eigenvalue(A)
+    @test  (5+sqrt(big(5)))/2 ≤ ρ
+end
+
+@testset "verified eigenvalues of symmetric matrix" begin
+    n = 10 # matrix size
+    ev = sort(randn(n))
+    D = Diagonal(ev)
+    Q, _ = qr(rand(n, n))
+    A = Symmetric(IA.Interval.(Q) * D * IA.Interval.(Q)')
+
+    F, cert = verify_eigenvalues(A)
+    @test all(cert)
+    @test all(ev .∈ F.values)
+end

--- a/test/test_eigenvalues/test_verify_eigs.jl
+++ b/test/test_eigenvalues/test_verify_eigs.jl
@@ -4,12 +4,32 @@
     @test  (5+sqrt(big(5)))/2 ≤ ρ
 end
 
-@testset "verified eigenvalues of symmetric matrix" begin
-    n = 10 # matrix size
+@testset "verified eigenvalues" begin
+    n = 5 # matrix size
+
+    # symmetric case
     ev = sort(randn(n))
     D = Diagonal(ev)
     Q, _ = qr(rand(n, n))
     A = Symmetric(IA.Interval.(Q) * D * IA.Interval.(Q)')
+
+    evals, evecs, cert = verify_eigen(A)
+    @test all(cert)
+    @test all(ev .∈ evals)
+
+
+    # real eigenvalues case
+    P = rand(n, n)
+    Pinv, _ = epsilon_inflation(P, Diagonal(ones(n)))
+    A = IA.Interval.(P) * IA.Interval.(D) * Pinv
+
+    evals, evecs, cert = verify_eigen(A)
+    @test all(cert)
+    @test all(ev .∈ evals)
+
+    # test complex eigenvalues
+    ev = sort(rand(Complex{Float64}, n), by = x -> (real(x), imag(x)))
+    A = IA.Interval.(P) * Matrix(Diagonal(ev)) * Pinv
 
     evals, evecs, cert = verify_eigen(A)
     @test all(cert)


### PR DESCRIPTION
extending to non-symmetric matrices requires this PR in IntervalArithmetic.jl https://github.com/JuliaIntervals/IntervalArithmetic.jl/pull/483 (requires computing magnitude and checking for strict inclusion of interval vectors)

