### PR TITLE
use isinterior in verified floating point operations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 CommonSolve = "0.2"
-IntervalArithmetic = "0.19.1"
+IntervalArithmetic = "0.19.2"
 LazySets = "1.47.2"
 Reexport = "1"
 Requires = "1"

--- a/src/eigenvalues/verify_eigs.jl
+++ b/src/eigenvalues/verify_eigs.jl
@@ -101,7 +101,7 @@ function _verify_eigen(A, λ::Number, X0::AbstractVector;
         Ytmp[v] = 0
 
         X = Z + C * Y + R * Ytmp
-        cert = all(X .⊂ Y)
+        cert = all(isinterior.(X, Y))
         cert && break
     end
 

--- a/src/linear_systems/verify.jl
+++ b/src/linear_systems/verify.jl
@@ -89,7 +89,7 @@ function epsilon_inflation(A::AbstractMatrix{T}, b::AbstractArray{S, N};
     for _ in 1:iter_max
         y = r1 * x .+ ϵ1
         x = z + C * y
-        if all(x .⊂ y)
+        if all(isinterior.(x, y))
             return xs + x, true
         end
     end


### PR DESCRIPTION
## PR description
<!-- A short description of what is done in this PR. -->

Use `isinterior` instead of strict subset in epsilon inflation and verified eigenvalue computation, as it should be.

## Related issues
<!--
List the issues related to this PR. E.g.
- #01
- #02

If you are closing some issues add "fixes" before the issue number, e.g.
- fixes #01
- #02
-->
- fixes #93 

## Checklist
<!-- Needed only if you change the source code.
You don't need to get everything done before opening the PR :) -->
- [x] Updated/added tests
- [x] Updated/added docstring (needed only for exported functions)
- [x] Updated Project.toml

## Other
<!-- Add here any other relevant information. -->