### PR TITLE
throw error if hbr is used with a non-H-matrix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalLinearAlgebra"
 uuid = "92cbe1ac-9c24-436b-b0c9-5f7317aedcd5"
 authors = ["Luca Ferranti"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/src/linear_systems/enclosures.jl
+++ b/src/linear_systems/enclosures.jl
@@ -69,6 +69,7 @@ function (hbr::HansenBliekRohn)(A::AbstractMatrix{T},
 
     cert || @warn "Could not find a verified enclosure of ⟨A⟩⁻¹"
 
+    all(sum(compA_inv; dims=2) .> 0) || throw(ArgumentError("applying Hanben-Bliek-Rohn to a non-H-matrix."))
     u = compA_inv * mag.(b)
     d = diag(compA_inv)
 


### PR DESCRIPTION
## PR description
<!-- A short description of what is done in this PR. -->

inside Hansen-Bliek-Rohn algorithm, check that the matrix is H-matrix and throw an error if it isn't
