### PR TITLE
fix printing of arrays of affine expressions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalLinearAlgebra"
 uuid = "92cbe1ac-9c24-436b-b0c9-5f7317aedcd5"
 authors = ["Luca Ferranti"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/src/pils/affine_expressions.jl
+++ b/src/pils/affine_expressions.jl
@@ -88,29 +88,37 @@ end
 
 (ae::AffineExpression)(p::Vector{<:Number}) = dot(ae.coeffs[1:end-1], p) + ae.coeffs[end]
 
-## printing
-function _tostring(ae::AffineExpression)
-    iszero(ae.coeffs) && return "0"
-    str = ""
-    @inbounds for (i, x) in enumerate(_vars_dict[:vars])
-        c = ae.coeffs[i]
-        iszero(c) && continue
-        sgn = c > 0 ? "+" : "-"
-        c = abs(c) == 1 ? "" : "$(abs(c))"
-        str *= sgn * c * "$(x)"
-    end
+function show(io::IO, ae::AffineExpression)
+    first_printed = false
+    if iszero(ae.coeffs)
+        print(io, 0)
+    else
+        @inbounds for (i, x) in enumerate(_vars_dict[:vars])
+            c = ae.coeffs[i]
+            iszero(c) && continue
+            if c > 0
+                if first_printed
+                    print(io, "+")
+                end
+            else
+                print(io, "-")
+            end
+            if abs(c) != 1
+                print(io, abs(c))
+            end
+            print(io, x)
+            first_printed = true
+        end
 
-    c = last(ae.coeffs)
-    if !iszero(c)
-        sgn = c > 0 ? "+" : ""
-        str *= sgn * "$(c)"
+        c = last(ae.coeffs)
+        if !iszero(c)
+            if c > 0 && first_printed
+                print(io, "+")
+            end
+            print(io, c)
+        end
     end
-    str = (str[1] == '+' ? str[2:end] : str)
-    return str
 end
-
-show(io::IO, ae::AffineExpression) = print(io, _tostring(ae))
-
 
 #########################
 # BASIC FUNCTIONS       #

--- a/test/test_pils/test_linexpr.jl
+++ b/test/test_pils/test_linexpr.jl
@@ -25,11 +25,10 @@ end
     @affinevars x y z
 
     p1 = x - y + 3z
-    @test IntervalLinearAlgebra._tostring(p1) == "x-y+3z"
+    @test string(p1) == "x-y+3z"
     p2 = y + x - z - 2
-    @test IntervalLinearAlgebra._tostring(p2) == "x+y-z-2"
-    @test IntervalLinearAlgebra._tostring(p1 - p1) == "0"
-
+    @test string(p2) == "x+y-z-2"
+    @test string(p1 - p1) == "0"
     @test +p1 == p1
     @test -p1 == -x + y - 3z
     @test p2([1, 1, 1]) == -1


### PR DESCRIPTION
## PR description
<!-- A short description of what is done in this PR. -->
Before, printing arrays of affine xpressions was using too many decimals, making it hard to read.

## Before 
<!-- Small example showing the functionality before this PR.
Needed only if you are changing existing source code (e.g. bug fix) -->
```julia
julia> @affinevars x y;

julia> [x+1/6*y-1 1/3*x+1/7;-x-1/9 1/11]
2×2 Matrix{AffineExpression{Float64}}:
 x+0.16666666666666666y-1.0  0.3333333333333333x+0.14285714285714285
 -x-0.1111111111111111       0.09090909090909091
```
## After
<!-- Small example showing the functionality added/changed in this PR. 
Needed only if you change the source code. -->

```julia
julia> @affinevars x y;

julia> [x+1/6*y-1 1/3*x+1/7;-x-1/9 1/11]
2×2 Matrix{AffineExpression{Float64}}:
 x+0.166667y-1.0  0.333333x+0.142857
 -x-0.111111      0.0909091
```

## Related issues
<!--
List the issues related to this PR. E.g.
- #01
- #02

If you are closing some issues add "fixes" before the issue number, e.g.
- fixes #01
- #02
-->

## Checklist
<!-- Needed only if you change the source code.
You don't need to get everything done before opening the PR :) -->
- [x] Updated/added tests
- [ ] Updated/added docstring (needed only for exported functions)
- [x] Updated Project.toml

## Other
<!-- Add here any other relevant information. -->