### PR TITLE
fix typo in docstring

### DIFF
--- a/src/eigenvalues/interval_eigenvalues.jl
+++ b/src/eigenvalues/interval_eigenvalues.jl
@@ -6,7 +6,7 @@ struct Rohn <: AbstractIntervalEigenSolver end
 """
     eigenbox(A[, method=Rohn()])
 
-Returns an enclosure of all the eigenvalues of `A`. If `A` is symmetric, than the
+Returns an enclosure of all the eigenvalues of `A`. If `A` is symmetric, then the
 output is a real interval, otherwise it is a complex interval.
 
 ### Input


### PR DESCRIPTION
fix typo in docstring

## PR description
<!-- A short description of what is done in this PR. -->
fix then / than typo in docstring
