### PR TITLE
don't redefine mid for reals here

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.julia-version == 'nightly' }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.version == 'nightly' }}
+    continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,3 @@ julia = "1.6"
 [extras]
 IntervalConstraintProgramming = "138f1668-1576-5ad7-91b9-7425abbf3153"
 LazySets = "b4f0291d-fe17-52bc-9479-3d1a343d9043"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test", "IntervalConstraintProgramming", "LazySets"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalLinearAlgebra"
 uuid = "92cbe1ac-9c24-436b-b0c9-5f7317aedcd5"
 authors = ["Luca Ferranti"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
@@ -13,7 +13,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 CommonSolve = "0.2"
-IntervalArithmetic = "0.20"
+IntervalArithmetic = "0.20.5"
 IntervalConstraintProgramming = "0.12"
 LazySets = "1.47.2"
 Reexport = "1"

--- a/src/IntervalLinearAlgebra.jl
+++ b/src/IntervalLinearAlgebra.jl
@@ -7,7 +7,6 @@ import Base: +, -, *, /, \, ==,
             show, convert, promote_rule, zero, one,
             getindex, IndexStyle, setindex!, size
 import CommonSolve: solve
-import IntervalArithmetic: mid
 
 @reexport using LinearAlgebra, IntervalArithmetic
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,3 @@
-mid(x::Real) = x
-mid(x::Complex) = x
-
 """
     interval_isapprox(a::Interval, b::Interval; kwargs)
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,10 @@
+[deps]
+IntervalConstraintProgramming = "138f1668-1576-5ad7-91b9-7425abbf3153"
+LazySets = "b4f0291d-fe17-52bc-9479-3d1a343d9043"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+IntervalConstraintProgramming = "0.12"
+LazySets = "1.47.2"
+StaticArrays = "0.12, 1"


### PR DESCRIPTION
## PR description
<!-- A short description of what is done in this PR. -->
before, ILA was redefining `mid(x::Real)` here, as this has been introduced in IntervalArithmetic 0.20.5, no need to do it anymore.
