### PR TITLE
speed up H-matrix test

### DIFF
--- a/src/classify.jl
+++ b/src/classify.jl
@@ -69,8 +69,9 @@ function is_H_matrix(A::AbstractMatrix{T}) where {T<:Interval}
     m == n || return false
 
     compA = comparison_matrix(A)
-    rank(compA) == n || return false
-    return all(compA\ones(n) .> 0)
+    F = lu(compA; check=false)
+    issuccess(F) || return false
+    return all(>(0), F\ones(n))
 end
 
 


### PR DESCRIPTION
## PR description
<!-- A short description of what is done in this PR. -->
Profiling the PILS solver, I noticed most time was spent on the H-matrix test, this PR speeds up the test. The benchmarks below show testing whether a `449x449` matrix is an H-matrix and the overal time for the solver from the continuum mechanics FEM example

## Before 
<!-- Small example showing the functionality before this PR.
Needed only if you are changing existing source code (e.g. bug fix) -->

```julia
julia> @btime is_H_matrix($D) # size 449 x 449, this is the comparison matrix computed in the parametric solver
  126.968 ms (21 allocations: 6.43 MiB)
true

julia> @btime solve($K, $FLib, $Erange)
  180.183 ms (68 allocations: 25.18 MiB)
```
## After
<!-- Small example showing the functionality added/changed in this PR. 
Needed only if you change the source code. -->

```julia
julia> @btime is_H_matrix($D)
  9.605 ms (9 allocations: 4.63 MiB)
true

julia> @btime solve($K, $FLib, $Erange)
  51.125 ms (56 allocations: 23.38 MiB)
```
