### PR TITLE
Avoid broadcast over Q in tests

### DIFF
--- a/test/test_eigenvalues/test_verify_eigs.jl
+++ b/test/test_eigenvalues/test_verify_eigs.jl
@@ -11,7 +11,7 @@ end
     ev = sort(randn(n))
     D = Diagonal(ev)
     Q, _ = qr(rand(n, n))
-    A = Symmetric(IA.Interval.(Q) * D * IA.Interval.(Q)')
+    A = Symmetric(IA.Interval.(Q * D * Q'))
 
     evals, evecs, cert = verify_eigen(A)
     @test all(cert)

--- a/test/test_eigenvalues/test_verify_eigs.jl
+++ b/test/test_eigenvalues/test_verify_eigs.jl
@@ -11,7 +11,7 @@ end
     ev = sort(randn(n))
     D = Diagonal(ev)
     Q, _ = qr(rand(n, n))
-    A = Symmetric(IA.Interval.(Q * D * Q'))
+    A = Symmetric(IA.Interval.(Matrix(Q)) * D * IA.Interval.(Matrix(Q')))
 
     evals, evecs, cert = verify_eigen(A)
     @test all(cert)


### PR DESCRIPTION
## PR description

Shouldn't my proposal yield the same result? I'm proposing this since broadcast over a `Q` matrix that has rather expensive `getindex` is somewhat an "abuse" of the fact that `AbstractQ <: AbstractMatrix`, see https://github.com/JuliaLang/julia/pull/46196. This popped up in a nanosoldier run. I'm sure this is just a quick convenience usage here, in real-life code this would be horribly slow.

In case it matters if you interval-lify before the product, one could replace this line by

```julia
A = Symmetric(IA.Interval.(Matrix(Q)) * D * IA.Interval.(Matrix(Q')))
```