### PR TITLE
Implemented Theorem 7 in Miya14

### DIFF
--- a/docs/src/api/eigenvalues.md
+++ b/docs/src/api/eigenvalues.md
@@ -20,3 +20,10 @@ Pages=["verify_eigs.jl"]
 Private=false
 ```
 
+## Singular Values Verification
+
+```@autodocs
+Modules=[IntervalLinearAlgebra]
+Pages=["miyajima_svd.jl"]
+Private=false
+```

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -104,6 +104,34 @@ L. Jaulin and B. Desrochers, [*Introduction to the algebra of separators with ap
 ```
 ---
 
+
+#### [MIYA14]
+
+```@raw html
+<ul><li>
+```
+S. Miyajima, *Verified bounds for all the singular values of matrix*, CJapan J. Indust. Appl. Math. DOI 10.1007/s13160-014-0145-5 
+```@raw html
+<li style="list-style: none"><details>
+<summary>bibtex</summary>
+```
+```
+@article{miyajima2014svd,
+  title={Verified bounds for all the singular values of matrix},
+  author={Miyajima, Shinya},
+  journal={Japan Journal of Industrial and Applied Mathematics},
+  volume={31},
+  pages={513--539},
+  year={2014},
+  publisher={Springer}
+}
+```
+```@raw html
+</details></li></ul>
+```
+---
+
+
 #### [NEU90]
 
 ```@raw html

--- a/src/IntervalLinearAlgebra.jl
+++ b/src/IntervalLinearAlgebra.jl
@@ -42,6 +42,7 @@ include("pils/pils_solvers.jl")
 
 include("eigenvalues/interval_eigenvalues.jl")
 include("eigenvalues/verify_eigs.jl")
+include("eigenvalues/miyajima_svd.jl")
 
 function  __init__()
     @require IntervalConstraintProgramming = "138f1668-1576-5ad7-91b9-7425abbf3153" include("linear_systems/oettli_nonlinear.jl")

--- a/src/eigenvalues/miyajima_svd.jl
+++ b/src/eigenvalues/miyajima_svd.jl
@@ -1,0 +1,105 @@
+# In this file we implement some of the algorithms from
+#
+# Shinya Miyajima
+#
+# Verified bounds for all the singular values of matrix
+# Japan J. Indust. Appl. Math.
+# DOI 10.1007/s13160-014-0145-5 
+
+abstract type AbstractIntervalSVDSolver end
+
+struct M1 <: AbstractIntervalSVDSolver end
+
+# The method is called svdbox to mirror eigenbox, even if it would be best to call it 
+# svd interval
+
+using LinearAlgebra
+
+function _power_iteration_singularvalue(A, max_iter)
+    n = size(A, 2)
+    xp = rand(n)
+    @inbounds for _ in 1:max_iter
+    xp .= A'*(A*xp)
+    xp ./= norm(xp)
+    end
+    return xp
+end
+
+
+function _bound_perron_frobenius_singularvalue(M, max_iter=10)
+
+    size(M) == (1, 1) && return M[1]
+    xpf = IA.Interval.(_power_iteration_singularvalue(mid.(M), max_iter))
+    Mxpf = M'* (M * xpf)
+    ρ = zero(eltype(M))
+    @inbounds for (i, xi) in enumerate(xpf)
+        iszero(xi) && continue
+        tmp = Mxpf[i] / xi
+        ρ = max(ρ, tmp.hi)
+    end
+    return ρ
+end
+
+
+"""
+    svdbox(A[, method = M1()])
+
+Return an enclosure for all the singular values of `A`.
+
+# Input 
+-   `A` -- interval matrix
+- `method` -- the method used to compute the enclosure
+    Possible values are
+        - M1 Algorithm from Theorem 7 in [[MIYA14]](@ref)
+
+### Algorithm 
+
+The algorithms used by the function are described in [[MIYA14]](@ref).
+
+### Example
+The matrix encloses a matrix that has singular values 
+``3, √5, 2, 0``.
+
+```julia
+julia> A = [0.9..1.1 0 0 0 2; 0 0 3 0 0; 0 0 0 0 0; 0 2 0 0 0]
+4×5 Matrix{Interval{Float64}}:
+     [0.899999, 1.10001]  [0, 0]  [0, 0]  [0, 0]  [2, 2]
+ [0, 0]                   [0, 0]  [3, 3]  [0, 0]  [0, 0]
+ [0, 0]                   [0, 0]  [0, 0]  [0, 0]  [0, 0]
+ [0, 0]                   [2, 2]  [0, 0]  [0, 0]  [0, 0]
+
+ julia> IntervalLinearAlgebra.svdbox(A, IntervalLinearAlgebra.M1())
+ 4-element Vector{Interval{Float64}}:
+   [2.98999, 3.01001]
+   [2.22606, 2.24607]
+   [1.98999, 2.01001]
+  [-0.0100001, 0.0100001]
+```
+
+"""
+function svdbox(A::AbstractMatrix{Interval{T}}, ::M1) where T
+    mA = mid.(A)
+    svdA  = svd(mA)
+    U = Interval{T}.(svdA.U)
+    Vt = Interval{T}.(svdA.Vt)
+    Σ = diagm(Interval{T}.(svdA.S))
+    V = Interval{T}.(svdA.V)
+
+    E = U*Σ*Vt - A
+    normE = _bound_perron_frobenius_singularvalue(E)
+    
+    F = Vt*V-I
+    normF = _bound_perron_frobenius_singularvalue(F)
+
+    G = U'*U-I
+    normG = _bound_perron_frobenius_singularvalue(G)
+
+    @assert normF < 1 "It is not possible to verify the singular values with this precision"
+    @assert normG < 1 "It is not possible to verify the singular values with this precision"
+
+    svdbounds = [hull(σ*sqrt((1-normF)*(1-normG))-normE, 
+                     σ*sqrt((1+normF)*(1+normG))+normE)
+                for σ in diag(Σ)]
+
+    return svdbounds
+end

--- a/src/eigenvalues/miyajima_svd.jl
+++ b/src/eigenvalues/miyajima_svd.jl
@@ -25,7 +25,9 @@ function _power_iteration_singularvalue(A, max_iter)
     return xp
 end
 
-
+# we use this function to bound the $2$ norm of a matrix,
+# as remarked in Rump, Verified bounds for singular values,
+# Equation 3.3
 function _bound_perron_frobenius_singularvalue(M, max_iter=10)
 
     size(M) == (1, 1) && return M[1]
@@ -77,7 +79,7 @@ julia> A = [0.9..1.1 0 0 0 2; 0 0 3 0 0; 0 0 0 0 0; 0 2 0 0 0]
 ```
 
 """
-function svdbox(A::AbstractMatrix{Interval{T}}, ::M1) where T
+function svdbox(A::AbstractMatrix{Interval{T}}, method = ::M1) where T
     mA = mid.(A)
     svdA  = svd(mA)
     U = Interval{T}.(svdA.U)
@@ -86,13 +88,13 @@ function svdbox(A::AbstractMatrix{Interval{T}}, ::M1) where T
     V = Interval{T}.(svdA.V)
 
     E = U*Σ*Vt - A
-    normE = _bound_perron_frobenius_singularvalue(E)
+    normE = sqrt(_bound_perron_frobenius_singularvalue(E))
     
     F = Vt*V-I
-    normF = _bound_perron_frobenius_singularvalue(F)
+    normF = sqrt(_bound_perron_frobenius_singularvalue(F))
 
     G = U'*U-I
-    normG = _bound_perron_frobenius_singularvalue(G)
+    normG = sqrt(_bound_perron_frobenius_singularvalue(G))
 
     @assert normF < 1 "It is not possible to verify the singular values with this precision"
     @assert normG < 1 "It is not possible to verify the singular values with this precision"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ include("test_utils.jl")
 
 include("test_eigenvalues/test_interval_eigenvalues.jl")
 include("test_eigenvalues/test_verify_eigs.jl")
+include("test_eigenvalues/test_miyajima_svd.jl")
 include("test_solvers/test_enclosures.jl")
 include("test_solvers/test_epsilon_inflation.jl")
 include("test_solvers/test_precondition.jl")

--- a/test/test_eigenvalues/test_miyajima_svd.jl
+++ b/test/test_eigenvalues/test_miyajima_svd.jl
@@ -1,0 +1,12 @@
+@testset "verify singular value perron frobenius " begin
+    A = [0.5 0.5;0.3 0.7]
+    ρ = IntervalLinearAlgebra._bound_perron_frobenius_singularvalue(A)
+    @test  1 ≤ ρ
+end
+
+@testset "verified svd" begin
+    A = [0.9..1.1 0 0 0 2; 0 0 3 0 0; 0 0 0 0 0; 0 2 0 0 0]
+    Σ = IntervalLinearAlgebra.svdbox(A, IntervalLinearAlgebra.M1())
+
+    @test all([3 ∈ Σ[1], 5 ∈ Σ[2]^2, 2 ∈ Σ[3], 0 ∈ Σ[4]])
+end


### PR DESCRIPTION
## PR description
Implemented Algorithm M1 based on Theorem 7 of
https://link.springer.com/article/10.1007/s13160-014-0145-5

## After
The, not exported function svdbox, allows to compute rigorous enclosures of the singular values of a matrix (rectangular and square)

## Checklist

- [X] Updated/added tests
- [X] Updated/added docstring (needed only for exported functions) 

## Other
I did not export the function yet