### PR TITLE
Fix complex matrix multiplication

### DIFF
--- a/src/multiplication.jl
+++ b/src/multiplication.jl
@@ -38,6 +38,21 @@ function set_multiplication_mode(multype)
     config[:multiplication] = multype
 end
 
+function *(A::AbstractMatrix{Complex{Interval{T}}}, B::AbstractMatrix) where T
+    return real(A)*B+im*imag(A)*B
+end
+
+function *(A::AbstractMatrix, B::AbstractMatrix{Complex{Interval{T}}}) where T
+    return A*real(B)+im*A*imag(B)
+end
+
+function *(A::AbstractMatrix{Complex{Interval{T}}}, B::AbstractMatrix{Complex{Interval{T}}}) where T
+    rA, iA = real(A), imag(A)
+    rB, iB = real(B), imag(B)
+    return rA*rB-iA*iB+im*(iA*rB+rA*iB)
+end
+
+
 function *(::MultiplicationType{:slow}, A, B)
     TS = promote_type(eltype(A), eltype(B))
     return mul!(similar(B, TS, (size(A,1), size(B,2))), A, B)

--- a/src/multiplication.jl
+++ b/src/multiplication.jl
@@ -52,6 +52,14 @@ function *(A::AbstractMatrix{Complex{Interval{T}}}, B::AbstractMatrix{Complex{In
     return rA*rB-iA*iB+im*(iA*rB+rA*iB)
 end
 
+function *(A::AbstractMatrix{Complex{T}}, B::AbstractMatrix{Interval{T}}) where {T}
+    return real(A)*B+im*imag(A)*B
+end
+
+function *(A::AbstractMatrix{Interval{T}}, B::AbstractMatrix{Complex{T}}) where {T}
+    return A*real(B)+im*A*imag(B)
+end
+
 
 function *(::MultiplicationType{:slow}, A, B)
     TS = promote_type(eltype(A), eltype(B))

--- a/test/test_multiplication.jl
+++ b/test/test_multiplication.jl
@@ -4,14 +4,22 @@
     @test get_multiplication_mode() == Dict(:multiplication => :fast)
 
     A = [2..4 -2..1; -1..2 2..4]
+    imA = im*A 
+    
     set_multiplication_mode(:slow)
     @test A * A == [0..18 -16..8; -8..16 0..18]
+    @test imA * imA == -1*[0..18 -16..8; -8..16 0..18]
 
     set_multiplication_mode(:rank1)
     @test A * A == [0..18 -16..8; -8..16 0..18]
+    @test imA * imA == -1*[0..18 -16..8; -8..16 0..18]
 
     set_multiplication_mode(:fast)
     @test A * A == [-2..19.5 -16..10; -10..16 -2..19.5]
     @test A * mid.(A) == [5..12.5 -8..2; -2..8 5..12.5]
     @test mid.(A) * A == [5..12.5 -8..2; -2..8 5..12.5]
+    
+    @test imA * imA == -1*[-2..19.5 -16..10; -10..16 -2..19.5]
+    @test mid.(A) * imA == im*[5..12.5 -8..2; -2..8 5..12.5]
+    @test imA * mid.(A) == im*[5..12.5 -8..2; -2..8 5..12.5]
 end


### PR DESCRIPTION
## PR description
We define new methods so that multiplication with complex interval matrices is correctly dispatched

## Before 
The compiler dispatched to the slow multiplication method

## After
The matrix product with complex matrices is dispatched correctly and uses the multiplication function exported by IntervalLinearAlgebra

## Related issues
<!--
If you are closing some issues add "fixes" before the issue number, e.g.
- fixes #85 
-->

## Checklist
<!-- Needed only if you change the source code.
You don't need to get everything done before opening the PR :) -->
- [X] Updated/added tests