### PR TITLE
Add missing prefix for radius

### DIFF
--- a/src/eigenvalues/interval_eigenvalues.jl
+++ b/src/eigenvalues/interval_eigenvalues.jl
@@ -48,7 +48,7 @@ julia> eigenbox(A, Hertz())
 """
 function eigenbox(A::Symmetric{Interval{T}, Matrix{Interval{T}}}, ::Rohn) where {T}
 
-    AΔ = Symmetric(radius.(A))
+    AΔ = Symmetric(IntervalArithmetic.radius.(A))
     Ac = Symmetric(mid.(A))
 
     ρ = eigmax(AΔ)


### PR DESCRIPTION
`eigenbox` is currently failing with
```julia
Stacktrace:
  [1] eigenbox(A::Symmetric{Interval{Float64}, Matrix{Interval{Float64}}}, ::IntervalLinearAlgebra.Rohn)
    @ IntervalLinearAlgebra ~/.julia/packages/IntervalLinearAlgebra/2hpkP/src/eigenvalues/interval_eigenvalues.jl:51
  [2] eigenbox(A::Matrix{Interval{Float64}}, method::IntervalLinearAlgebra.Rohn)
    @ IntervalLinearAlgebra ~/.julia/packages/IntervalLinearAlgebra/2hpkP/src/eigenvalues/interval_eigenvalues.jl:95
  [3] eigenbox(A::Matrix{Interval{Float64}})
    @ IntervalLinearAlgebra ~/.julia/packages/IntervalLinearAlgebra/2hpkP/src/eigenvalues/interval_eigenvalues.jl:126
```
Looking at other places where `radius` is used in the package, it seems that it's simply not exported by `IntervalArithmetic` so we need an explicit prefix