### PR TITLE
use extensions instead of requires when usable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,21 @@ version = "0.1.6"
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
+IntervalConstraintProgramming = "138f1668-1576-5ad7-91b9-7425abbf3153"
+LazySets = "b4f0291d-fe17-52bc-9479-3d1a343d9043"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OpenBLASConsistentFPCSR_jll = "6cdc7f73-28fd-5e50-80fb-958a8875b1af"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[extensions]
+IntervalConstraintProgrammingExt = "IntervalConstraintProgramming"
+LazySetsExt = "LazySets"
+
+[weakdeps]
+IntervalConstraintProgramming = "138f1668-1576-5ad7-91b9-7425abbf3153"
+LazySets = "b4f0291d-fe17-52bc-9479-3d1a343d9043"
 
 [compat]
 CommonSolve = "0.2"

--- a/ext/IntervalConstraintProgrammingExt.jl
+++ b/ext/IntervalConstraintProgrammingExt.jl
@@ -1,4 +1,12 @@
-using .IntervalConstraintProgramming
+module IntervalConstraintProgrammingExt
+
+if !isdefined(Base, :get_extension)
+    using ..IntervalLinearAlgebra
+    using ..IntervalConstraintProgramming
+else
+    using IntervalLinearAlgebra
+    using IntervalConstraintProgramming
+end
 
 """
 returns the unrolled expression for \$|a ⋅x - b|\$
@@ -44,18 +52,17 @@ function oettli_eq(a, b, x)
     rhs = oettli_rhs(ar, br, x)
     ex = :(@constraint $lhs - $rhs <= 0)
     @eval $ex
-
 end
 
-
-
-function (op::NonLinearOettliPrager)(A, b, X::IntervalBox)
+function (op::IntervalLinearAlgebra.NonLinearOettliPrager)(A, b, X::IntervalBox)
     vars = ntuple(i -> Symbol(:x, i), length(b))
     separators = [oettli_eq(A[i,:], b[i], vars) for i in 1:length(b)]
     S = reduce(∩, separators)
     return Base.invokelatest(pave, S, X, op.tol)
 end
 
-(op::NonLinearOettliPrager)(A, b, X=enclose(A, b)) = op(A, b, IntervalBox(X))
+(op::IntervalLinearAlgebra.NonLinearOettliPrager)(A, b, X=enclose(A, b)) = op(A, b, IntervalBox(X))
 
-_default_precondition(_, ::NonLinearOettliPrager) = NoPrecondition()
+IntervalLinearAlgebra._default_precondition(_, ::NonLinearOettliPrager) = NoPrecondition()
+
+end

--- a/ext/LazySetsExt.jl
+++ b/ext/LazySetsExt.jl
@@ -1,6 +1,14 @@
-using .LazySets
+module LazySetsExt
 
-function (opl::LinearOettliPrager)(A, b)
+if !isdefined(Base, :get_extension)
+    using ..IntervalLinearAlgebra
+    using ..LazySets
+else
+    using IntervalLinearAlgebra
+    using LazySets
+end
+
+function (opl::IntervalLinearAlgebra.LinearOettliPrager)(A, b)
     n = length(b)
     Ac = mid.(A)
     bc = mid.(b)
@@ -22,4 +30,6 @@ function (opl::LinearOettliPrager)(A, b)
     return identity.(filter!(!isempty, polytopes))
 end
 
-_default_precondition(_, ::LinearOettliPrager) = NoPrecondition()
+IntervalLinearAlgebra._default_precondition(_, ::LinearOettliPrager) = NoPrecondition()
+
+end


### PR DESCRIPTION
This fixes the package on 1.12 (failing due to both LazySets and IntervalLinearAlgebra defining an `Intervarl` name).

Tangentially, this package also fails on 1.6 due to using `BLAS.lbt_forward`, which is not defined there. Might warrant a bump to julia 1.10.